### PR TITLE
Add href to MenuItem

### DIFF
--- a/src/lib/components/Menu/MenuItem.svelte
+++ b/src/lib/components/Menu/MenuItem.svelte
@@ -31,6 +31,7 @@
 	bind:this={self}
 	use:useActions={use}
 	class={classProp(klass, ctx.state)}
+	{href}
 	{...ctx.attrs}
 	{...props}
 >

--- a/src/lib/components/Menu/MenuItem.svelte
+++ b/src/lib/components/Menu/MenuItem.svelte
@@ -29,9 +29,9 @@
 <svelte:element
 	this={href ? 'a' : 'button'}
 	bind:this={self}
+	href={href || undefined}
 	use:useActions={use}
 	class={classProp(klass, ctx.state)}
-	{href}
 	{...ctx.attrs}
 	{...props}
 >


### PR DESCRIPTION
Since href is extracted from `$props()` it is no longer a part of `{...props}` and needs to be added to `<svelte:element>` separately.